### PR TITLE
Don't pin colorlog to a strict version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "colorlog==6.8.2",
+    "colorlog>=6.8.2",
     "aiohttp>=3.8.5",
     "websockets>=11.0.3",
 ]


### PR DESCRIPTION
The `colorlog` package is currently pinned to a strict version: `colorlog==6.8.2`

This causes an issue for Home Assistant, as we want to update `colorlog` to the latest version. This package prevents that.

In general, the best practice for libraries is not to strictly pin, as that makes using libraries harder.

This PR loosens the pinning for the `colorlog` package by only setting the lower boundary, as was also done with all other packages in this library.

../Frenck

PS: A release after this merge would be appreciated, as it would unblock the upgrade of the package on the Home Assistant end. 🙏 